### PR TITLE
feat: SearchData Store에 검색데이터 캐싱 및 fetch 코드 분리

### DIFF
--- a/src/store/SearchData.js
+++ b/src/store/SearchData.js
@@ -1,0 +1,41 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+
+const initialState = {
+  data: [],
+  status: "",
+};
+
+export const asyncSearchFetch = createAsyncThunk("searchDataSlice/asyncSearchFetch", async ({ searchInput, token }) => {
+  try {
+    const response = await fetch(`https://mandarin.api.weniv.co.kr/user/searchuser/?keyword=${searchInput}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-type": "application/json",
+      },
+    });
+    const users = await response.json();
+    return users;
+  } catch (error) {
+    console.log(error);
+  }
+});
+
+const searchDataSlice = createSlice({
+  name: "searchData",
+  initialState,
+  extraReducers: (builder) => {
+    builder.addCase(asyncSearchFetch.pending, (state, action) => {
+      state.status = "pending";
+    });
+    builder.addCase(asyncSearchFetch.fulfilled, (state, action) => {
+      state.status = "fulfilled";
+      state.data = action.payload;
+    });
+    builder.addCase(asyncSearchFetch.rejected, (state, action) => {
+      state.status = "rejected";
+    });
+  },
+});
+export const { SET_SEARCH_DATA } = searchDataSlice.actions;
+export default searchDataSlice.reducer;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,7 @@ import UserInfoReducer from "./UserInfo";
 import ProfileReducer from "./Profile";
 import RegisteredReducer from "./Register";
 import PostDetailReducer from "./PostDetail";
+import SearchDataReducer from "./SearchData";
 
 export default configureStore({
   reducer: {
@@ -12,5 +13,6 @@ export default configureStore({
     profile: ProfileReducer,
     signUp: RegisteredReducer,
     postDetail: PostDetailReducer,
+    searchData: SearchDataReducer,
   },
 });


### PR DESCRIPTION
## 🍀 무엇을 위한 PR인가요?

- [x] 기능 추가 : SearchData Store에 검색데이터 캐싱 및 fetch 코드 분리
- [ ] 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 :

## 🍀 기대 결과
- SearchData 컴포넌트에서 fetch 코드 분리로 인한 코드 간결화
- Store에 검색데이터 캐싱하여 뒤로가기시 같은 검색결과를 보여줄 수 있음

## 🍀 전달사항
- 없음

## 🍀 스크린샷

## 🍀 Issue Number

close : #177 
